### PR TITLE
Fix removeNoise function

### DIFF
--- a/src/main/java/org/torproject/metrics/stats/hidserv/Parser.java
+++ b/src/main/java/org/torproject/metrics/stats/hidserv/Parser.java
@@ -238,11 +238,44 @@ public class Parser {
   }
 
   /** Removes noise from a reported stats value by rounding to the nearest
-   * right side of a bin and subtracting half of the bin size. */
+   * right side of a bin and subtracting half of the bin size.
+   *
+   * For negative integers, the right side of the bin is the greater number
+   * (e.g. for a binsize of 8, and reportedNumber -9, the right side of the bin
+   * is -8) . */
   private long removeNoise(long reportedNumber, long binSize) {
-    long roundedToNearestRightSideOfTheBin =
-        Math.floorDiv((reportedNumber + binSize / 2), binSize) * binSize;
-    return roundedToNearestRightSideOfTheBin - binSize / 2;
+      long result;
+
+      /* Handle bad edge case */
+      if (binSize == 0) {
+          return reportedNumber;
+      }
+
+      /* remainder for positives is the distance to the left side of the bin
+       * (e.g. for binsize 8, remainder for 13 is 5 and remainder for 10 is 2)
+       *
+       * For negatives, remainder is the distance to the right side of the bin
+       * (e.g. for binsize 8, remainder for -1 is 1 and remainder for -18 is 2)
+       */
+      long remainder = Math.abs(reportedNumber) % binSize;
+      if (remainder == 0) {
+          return reportedNumber;
+      }
+
+      /* Now get to the right side of the bin */
+      long roundedToNearestRightSideOfTheBin;
+      if (reportedNumber < 0) {
+          roundedToNearestRightSideOfTheBin = -(Math.abs(reportedNumber) - remainder);
+      } else {
+          roundedToNearestRightSideOfTheBin = reportedNumber + binSize - remainder;
+      }
+
+      /* And now subtract half of the bin size from that */
+      result = roundedToNearestRightSideOfTheBin - binSize / 2;
+
+//      logger.warn("For reported number {} we went to: {} (right side of bin {}) (remainder {}) (binsize {})",
+//                  reportedNumber, result, roundedToNearestRightSideOfTheBin, remainder, binSize);
+      return result;
   }
 
   /** Parses the given consensus. */


### PR DESCRIPTION
Examples of bad invocations:

* For reported number 138 we went to: 132 (binsize 8)
* For reported number 43 we went to: 36 (binsize 8)
* For reported number -5 we went to: -12 (binsize 8)

Examples of fixed invocations:

* For reported number 138 we went to: 140 (right side of bin 144) (remainder 2) (binsize 8)
* For reported number 43 we went to: 44 (right side of bin 48) (remainder 3) (binsize 8)
* For reported number -5 we went to: -4 (right side of bin 0) (remainder 5) (binsize 8)

Code based on https://stackoverflow.com/a/3407254 .